### PR TITLE
feat: Centurion protocol support for headset battery monitoring

### DIFF
--- a/LGSTrayHID/Centurion/CenturionDevice.cs
+++ b/LGSTrayHID/Centurion/CenturionDevice.cs
@@ -1,0 +1,485 @@
+using LGSTrayHID.Battery;
+using LGSTrayHID.Features;
+using LGSTrayHID.HidApi;
+using LGSTrayHID.Metadata;
+using LGSTrayPrimitives;
+using LGSTrayPrimitives.MessageStructs;
+
+namespace LGSTrayHID.Centurion;
+
+/// <summary>
+/// Manages feature discovery and battery polling for a single Centurion headset.
+/// Supports both dongle mode (via CentPPBridge) and direct USB mode.
+///
+/// Centurion feature IDs:
+///   0x0000 = CenturionRoot (getFeature discovery)
+///   0x0001 = FeatureSet
+///   0x0003 = CentPPBridge (dongle-to-headset bridge)
+///   0x0100 = DeviceInfo
+///   0x0101 = DeviceName
+///   0x0104 = BatterySOC
+/// </summary>
+public class CenturionDevice : IDisposable
+{
+    private readonly CenturionTransport _transport;
+    private readonly ushort _usagePage;
+
+    // Feature indices discovered at init
+    private byte _bridgeIdx = 0xFF;     // CentPPBridge (0x0003) — 0xFF = not found
+    private byte _batterySocIdx = 0xFF; // BatterySOC (0x0104) — 0xFF = not found
+    private byte _deviceNameIdx = 0xFF; // DeviceName (0x0101) — 0xFF = not found
+
+    // Device state
+    private bool _isDongleMode;
+    private byte _subDeviceId = 0x01;   // Default sub-device ID for bridge mode
+    private string _deviceName = "Centurion Headset";
+    private string _identifier = string.Empty;
+
+    // Battery polling
+    private readonly BatteryUpdatePublisher _batteryPublisher = new();
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _pollingTask;
+    private Task? _readLoopTask;
+
+    private int _disposeCount = 0;
+
+    // Centurion feature IDs
+    private const ushort FEAT_FEATURE_SET = 0x0001;
+    private const ushort FEAT_CENTPP_BRIDGE = 0x0003;
+    private const ushort FEAT_DEVICE_INFO = 0x0100;
+    private const ushort FEAT_DEVICE_NAME = 0x0101;
+    private const ushort FEAT_BATTERY_SOC = 0x0104;
+
+    public CenturionDevice(HidDevicePtr dev, ushort usagePage, byte reportId = 0x51)
+    {
+        _transport = new CenturionTransport(dev, reportId);
+        _usagePage = usagePage;
+    }
+
+    public async Task InitAsync()
+    {
+        string tag = $"[Centurion 0x{_usagePage:X4}]";
+
+        try
+        {
+            DiagnosticLogger.Log($"{tag} Starting feature discovery...");
+
+            // Step 1: Discover parent features via CenturionRoot (index 0, func 0)
+            _bridgeIdx = await QueryFeatureIndex(FEAT_CENTPP_BRIDGE);
+            byte directBatterySocIdx = await QueryFeatureIndex(FEAT_BATTERY_SOC);
+            _deviceNameIdx = await QueryFeatureIndex(FEAT_DEVICE_NAME);
+
+            // Determine mode
+            if (_bridgeIdx != 0xFF)
+            {
+                _isDongleMode = true;
+                DiagnosticLogger.Log($"{tag} Dongle mode — CentPPBridge at index {_bridgeIdx}");
+                await InitDongleMode(tag);
+            }
+            else if (directBatterySocIdx != 0xFF)
+            {
+                _isDongleMode = false;
+                _batterySocIdx = directBatterySocIdx;
+                DiagnosticLogger.Log($"{tag} Direct mode — BatterySOC at index {_batterySocIdx}");
+            }
+            else
+            {
+                DiagnosticLogger.LogWarning($"{tag} No CentPPBridge or BatterySOC found — cannot monitor battery");
+                return;
+            }
+
+            // Step 2: Get device name if available
+            await TryGetDeviceName(tag);
+
+            // Step 3: Generate identifier (name-hash fallback since we don't have HID++ FW info)
+            _identifier = DeviceIdentifierGenerator.GenerateIdentifier(null, null, null, _deviceName);
+
+            // Step 4: Signal INIT to UI
+            string deviceSignature = $"NATIVE.{DeviceType.Headset}.{_identifier}";
+            HidppManagerContext.Instance.SignalDeviceEvent(
+                IPCMessageType.INIT,
+                new InitMessage(_identifier, _deviceName, hasBattery: true, DeviceType.Headset, deviceSignature)
+            );
+            DiagnosticLogger.Log($"{tag} Device registered: {_deviceName} ({_identifier})");
+
+            // Step 5: First battery read
+            await UpdateBattery(forceUpdate: true);
+
+            // Step 6: Start background read loop for unsolicited events
+            _readLoopTask = Task.Run(() => BackgroundReadLoop(_cts.Token), _cts.Token);
+
+            // Step 7: Start polling loop
+            _pollingTask = Task.Run(() => PollBattery(_cts.Token), _cts.Token);
+        }
+        catch (Exception ex)
+        {
+            DiagnosticLogger.LogError($"{tag} Init failed: {ex.Message}");
+        }
+    }
+
+    // ---- Dongle mode initialization ----
+
+    private async Task InitDongleMode(string tag)
+    {
+        // Check if headset is connected via CentPPBridge.getConnectionInfo (func 0)
+        await _transport.SendRequest(_bridgeIdx, func: 0x00, parameters: []);
+        var connResp = _transport.ReadResponse(timeoutMs: 2000);
+
+        if (connResp == null)
+        {
+            DiagnosticLogger.LogWarning($"{tag} No response from CentPPBridge.getConnectionInfo");
+            return;
+        }
+
+        // MTU > 0 means a sub-device is connected
+        // Response params: connection info varies by firmware, but any non-zero data indicates presence
+        if (connResp.Value.Params.Length > 0 && connResp.Value.Params.All(b => b == 0))
+        {
+            DiagnosticLogger.LogWarning($"{tag} Headset appears offline (bridge reports no connected device)");
+            return;
+        }
+
+        DiagnosticLogger.Log($"{tag} Headset connected via bridge");
+
+        // Discover BatterySOC on sub-device via bridge
+        // Route CenturionRoot.getFeature(0x0104) through bridge
+        _batterySocIdx = await QueryFeatureIndexViaBridge(FEAT_BATTERY_SOC);
+
+        if (_batterySocIdx == 0xFF)
+        {
+            DiagnosticLogger.LogWarning($"{tag} Sub-device does not expose BatterySOC (0x0104)");
+            return;
+        }
+
+        DiagnosticLogger.Log($"{tag} Sub-device BatterySOC at index {_batterySocIdx}");
+
+        // Also try to get device name from sub-device
+        byte subNameIdx = await QueryFeatureIndexViaBridge(FEAT_DEVICE_NAME);
+        if (subNameIdx != 0xFF)
+        {
+            _deviceNameIdx = subNameIdx; // Use sub-device name instead of dongle name
+        }
+    }
+
+    // ---- Feature discovery ----
+
+    /// <summary>
+    /// Query CenturionRoot (index 0, func 0 = getFeature) for a feature's index.
+    /// Returns 0xFF if not found.
+    /// </summary>
+    private async Task<byte> QueryFeatureIndex(ushort featureId)
+    {
+        byte[] featureIdBytes = [(byte)(featureId >> 8), (byte)(featureId & 0xFF)];
+        await _transport.SendRequest(featIdx: 0x00, func: 0x00, parameters: featureIdBytes);
+
+        var resp = _transport.ReadResponse(timeoutMs: 2000);
+        if (resp == null || resp.Value.Params.Length == 0)
+            return 0xFF;
+
+        byte index = resp.Value.Params[0];
+
+        // Index 0 typically means "not found" for non-root features
+        if (index == 0 && featureId != 0x0000)
+        {
+            DiagnosticLogger.Verbose($"[Centurion] Feature 0x{featureId:X4} not found (index=0)");
+            return 0xFF;
+        }
+
+        DiagnosticLogger.Log($"[Centurion] Feature 0x{featureId:X4} → index {index}");
+        return index;
+    }
+
+    /// <summary>
+    /// Query a feature index on the sub-device via CentPPBridge.
+    /// Routes CenturionRoot.getFeature() through the bridge envelope.
+    /// </summary>
+    private async Task<byte> QueryFeatureIndexViaBridge(ushort featureId)
+    {
+        byte[] featureIdBytes = [(byte)(featureId >> 8), (byte)(featureId & 0xFF)];
+
+        await _transport.SendBridgeRequest(
+            bridgeIdx: _bridgeIdx,
+            devId: _subDeviceId,
+            subFeatIdx: 0x00,     // CenturionRoot on sub-device
+            subFunc: 0x00,        // getFeature
+            subParams: featureIdBytes
+        );
+
+        var resp = _transport.ReadBridgeResponse(_bridgeIdx, timeoutMs: 3000);
+        if (resp == null || resp.Value.Params.Length == 0)
+            return 0xFF;
+
+        byte index = resp.Value.Params[0];
+        if (index == 0 && featureId != 0x0000)
+        {
+            DiagnosticLogger.Verbose($"[Centurion] Sub-device feature 0x{featureId:X4} not found");
+            return 0xFF;
+        }
+
+        DiagnosticLogger.Log($"[Centurion] Sub-device feature 0x{featureId:X4} → index {index}");
+        return index;
+    }
+
+    // ---- Device name ----
+
+    private async Task TryGetDeviceName(string tag)
+    {
+        if (_deviceNameIdx == 0xFF)
+            return;
+
+        try
+        {
+            // DeviceName func 0 = getNameLength, func 1 = getNameChunk
+            CenturionResponse? lengthResp;
+
+            if (_isDongleMode)
+            {
+                await _transport.SendBridgeRequest(_bridgeIdx, _subDeviceId, _deviceNameIdx, 0x00, []);
+                lengthResp = _transport.ReadBridgeResponse(_bridgeIdx, timeoutMs: 3000);
+            }
+            else
+            {
+                await _transport.SendRequest(_deviceNameIdx, 0x00, []);
+                lengthResp = _transport.ReadResponse(timeoutMs: 2000);
+            }
+
+            if (lengthResp == null || lengthResp.Value.Params.Length == 0)
+                return;
+
+            int nameLen = lengthResp.Value.Params[0];
+            if (nameLen == 0 || nameLen > 64)
+                return;
+
+            // Read name in chunks
+            var nameBytes = new List<byte>();
+            for (int offset = 0; offset < nameLen; offset += 16)
+            {
+                CenturionResponse? chunkResp;
+
+                if (_isDongleMode)
+                {
+                    await _transport.SendBridgeRequest(_bridgeIdx, _subDeviceId, _deviceNameIdx, 0x01, [(byte)offset]);
+                    chunkResp = _transport.ReadBridgeResponse(_bridgeIdx, timeoutMs: 3000);
+                }
+                else
+                {
+                    await _transport.SendRequest(_deviceNameIdx, 0x01, [(byte)offset]);
+                    chunkResp = _transport.ReadResponse(timeoutMs: 2000);
+                }
+
+                if (chunkResp == null || chunkResp.Value.Params.Length == 0)
+                    break;
+
+                nameBytes.AddRange(chunkResp.Value.Params);
+            }
+
+            if (nameBytes.Count > 0)
+            {
+                // Trim to actual length and strip null terminators
+                int actualLen = Math.Min(nameLen, nameBytes.Count);
+                string name = System.Text.Encoding.UTF8.GetString(nameBytes.ToArray(), 0, actualLen).TrimEnd('\0');
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    _deviceName = name;
+                    DiagnosticLogger.Log($"{tag} Device name: {_deviceName}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            DiagnosticLogger.LogWarning($"{tag} Failed to read device name: {ex.Message}");
+        }
+    }
+
+    // ---- Battery ----
+
+    private async Task<bool> UpdateBattery(bool forceUpdate = false)
+    {
+        if (_batterySocIdx == 0xFF)
+            return false;
+
+        try
+        {
+            CenturionResponse? resp;
+
+            if (_isDongleMode)
+            {
+                await _transport.SendBridgeRequest(_bridgeIdx, _subDeviceId, _batterySocIdx, 0x00, []);
+                resp = _transport.ReadBridgeResponse(_bridgeIdx, timeoutMs: 3000);
+            }
+            else
+            {
+                await _transport.SendRequest(_batterySocIdx, 0x00, []);
+                resp = _transport.ReadResponse(timeoutMs: 2000);
+            }
+
+            if (resp == null)
+            {
+                DiagnosticLogger.LogWarning("[Centurion] Battery query returned no response");
+                return false;
+            }
+
+            var batState = ParseBatterySOC(resp.Value.Params);
+            if (batState == null)
+                return false;
+
+            var now = DateTimeOffset.Now;
+            _batteryPublisher.PublishUpdate(_identifier, _deviceName, batState.Value, now, "poll", forceUpdate);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            DiagnosticLogger.LogWarning($"[Centurion] Battery update failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Parse BatterySOC (0x0104) response params.
+    /// Byte 0: SOC percentage (0-100)
+    /// Byte 1: SOC percentage (duplicate)
+    /// Byte 2: Charging status (0=discharging, 1=charging, 2=USB charging, 3=full)
+    /// </summary>
+    private static BatteryUpdateReturn? ParseBatterySOC(byte[] parameters)
+    {
+        if (parameters.Length < 3)
+        {
+            DiagnosticLogger.LogWarning($"[Centurion] BatterySOC response too short ({parameters.Length} bytes)");
+            return null;
+        }
+
+        byte soc = parameters[0];
+        byte chargingStatus = parameters[2];
+
+        // Clamp SOC to valid range
+        if (soc > 100)
+        {
+            DiagnosticLogger.LogWarning($"[Centurion] BatterySOC out of range: {soc}%, clamping to 100");
+            soc = 100;
+        }
+
+        var status = chargingStatus switch
+        {
+            0 => PowerSupplyStatus.DISCHARGING,
+            1 => PowerSupplyStatus.CHARGING,
+            2 => PowerSupplyStatus.CHARGING,    // USB charging → charging
+            3 => PowerSupplyStatus.FULL,
+            _ => PowerSupplyStatus.UNKNOWN,
+        };
+
+        DiagnosticLogger.Log($"[Centurion] Battery: {soc}% status={chargingStatus} → {status}");
+        return new BatteryUpdateReturn(soc, status, batteryMVolt: 0);
+    }
+
+    // ---- Polling ----
+
+    private async Task PollBattery(CancellationToken ct)
+    {
+        int intervalSeconds = GetPollInterval();
+        DiagnosticLogger.Log($"[Centurion] Battery polling started (interval: {intervalSeconds}s)");
+
+        try
+        {
+            // Initial delay before first poll (already did one read at init)
+            await Task.Delay(TimeSpan.FromSeconds(intervalSeconds), ct);
+
+            while (!ct.IsCancellationRequested)
+            {
+                await UpdateBattery();
+                await Task.Delay(TimeSpan.FromSeconds(intervalSeconds), ct);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown
+        }
+
+        DiagnosticLogger.Log("[Centurion] Battery polling stopped");
+    }
+
+    private static int GetPollInterval()
+    {
+#if DEBUG
+        return 30;
+#else
+        return Math.Clamp(GlobalSettings.settings.PollPeriod, 20, 3600);
+#endif
+    }
+
+    // ---- Background read loop for unsolicited events ----
+
+    private void BackgroundReadLoop(CancellationToken ct)
+    {
+        DiagnosticLogger.Log("[Centurion] Background read loop started");
+
+        _transport.ReadLoop(response =>
+        {
+            // Battery event: BatterySOC feature, func=0, swid=0 (unsolicited)
+            if (response.FeatIdx == _batterySocIdx && response.SwId == 0x00)
+            {
+                var batState = ParseBatterySOC(response.Params);
+                if (batState != null)
+                {
+                    var now = DateTimeOffset.Now;
+                    _batteryPublisher.PublishUpdate(_identifier, _deviceName, batState.Value, now, "event");
+                }
+            }
+
+            // Dongle mode: watch for bridge connection state changes
+            if (_isDongleMode && response.FeatIdx == _bridgeIdx && response.SwId == 0x00)
+            {
+                DiagnosticLogger.Log($"[Centurion] Bridge event received: func={response.FuncId} " +
+                                     $"params={BitConverter.ToString(response.Params)}");
+
+                // ConnectionStateChanged typically comes as func=0 event
+                // Re-query battery on reconnect
+                if (response.FuncId == 0x00)
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        await Task.Delay(1000); // Let device stabilize
+                        await UpdateBattery(forceUpdate: true);
+                    });
+                }
+            }
+        }, ct);
+
+        DiagnosticLogger.Log("[Centurion] Background read loop ended");
+    }
+
+    // ---- Disposal ----
+
+    public void Dispose()
+    {
+        if (Interlocked.Increment(ref _disposeCount) != 1)
+            return;
+
+        DiagnosticLogger.Log($"[Centurion] Disposing {_deviceName}");
+
+        _cts.Cancel();
+
+        // Wait briefly for tasks to exit
+        try { _pollingTask?.Wait(TimeSpan.FromSeconds(5)); } catch { /* expected */ }
+        try { _readLoopTask?.Wait(TimeSpan.FromSeconds(5)); } catch { /* expected */ }
+
+        // Send offline notification
+        if (!string.IsNullOrEmpty(_identifier))
+        {
+            HidppManagerContext.Instance.SignalDeviceEvent(
+                IPCMessageType.UPDATE,
+                new UpdateMessage(
+                    deviceId: _identifier,
+                    batteryPercentage: -1,
+                    powerSupplyStatus: PowerSupplyStatus.UNKNOWN,
+                    batteryMVolt: 0,
+                    updateTime: DateTimeOffset.Now
+                )
+            );
+        }
+
+        _transport.Dispose();
+        _cts.Dispose();
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/LGSTrayHID/Centurion/CenturionTransport.cs
+++ b/LGSTrayHID/Centurion/CenturionTransport.cs
@@ -1,0 +1,242 @@
+using LGSTrayHID.HidApi;
+using LGSTrayPrimitives;
+using static LGSTrayHID.HidApi.HidApi;
+
+namespace LGSTrayHID.Centurion;
+
+/// <summary>
+/// Parsed Centurion CPL response frame.
+/// </summary>
+public readonly record struct CenturionResponse(byte FeatIdx, byte FuncId, byte SwId, byte[] Params);
+
+/// <summary>
+/// Low-level Centurion CPL frame I/O on a single HID device handle.
+/// Handles both direct and bridge-wrapped (dongle) communication.
+///
+/// CPL frame format (64 bytes, zero-padded):
+///   [reportId] [cpl_length] [flags] [feat_idx] [func&lt;&lt;4 | swid] [params...]
+/// </summary>
+public class CenturionTransport : IDisposable
+{
+    private readonly HidDevicePtr _dev;
+    private readonly byte _reportId;
+
+    private const int FRAME_SIZE = 64;
+    private const byte FLAGS_SINGLE = 0x00;
+    private const byte SWID = 0x0A; // Match GlobalSettings default
+
+    public CenturionTransport(HidDevicePtr dev, byte reportId = 0x51)
+    {
+        _dev = dev;
+        _reportId = reportId;
+    }
+
+    /// <summary>
+    /// Build and send a direct CPL request frame.
+    /// </summary>
+    public async Task SendRequest(byte featIdx, byte func, byte[] parameters)
+    {
+        byte[] frame = BuildFrame(featIdx, func, parameters);
+        LogTx("Direct", featIdx, func, parameters);
+        await _dev.WriteAsync(frame);
+    }
+
+    /// <summary>
+    /// Build and send a CentPPBridge-wrapped request for sub-device communication (dongle mode).
+    ///
+    /// Bridge envelope format:
+    ///   [reportId] [cpl_length] [flags=0x00] [bridge_idx] [0x10|swid]
+    ///   [dev_id&lt;&lt;4 | len_hi] [len_lo]
+    ///   [sub_cpl=0x00] [sub_feat_idx] [sub_func|swid] [params...]
+    /// </summary>
+    public async Task SendBridgeRequest(byte bridgeIdx, byte devId, byte subFeatIdx, byte subFunc, byte[] subParams)
+    {
+        // Sub-device message: [sub_cpl=0x00] [sub_feat_idx] [sub_func|swid] [params...]
+        int subMsgLen = 3 + subParams.Length;
+
+        // Bridge header params: [devId<<4 | lenHi] [lenLo] [sub-message...]
+        byte[] bridgeParams = new byte[2 + subMsgLen];
+        bridgeParams[0] = (byte)((devId << 4) | ((subMsgLen >> 8) & 0x0F));
+        bridgeParams[1] = (byte)(subMsgLen & 0xFF);
+        bridgeParams[2] = FLAGS_SINGLE; // sub-device CPL flags
+        bridgeParams[3] = subFeatIdx;
+        bridgeParams[4] = (byte)((subFunc << 4) | SWID);
+        Array.Copy(subParams, 0, bridgeParams, 5, subParams.Length);
+
+        // Bridge outer frame: func=0x01 (sendMessage)
+        byte[] frame = BuildFrame(bridgeIdx, 0x01, bridgeParams);
+
+        DiagnosticLogger.Verbose($"[Centurion] TX Bridge: bridgeIdx={bridgeIdx} devId={devId} " +
+                                 $"subFeat=0x{subFeatIdx:X2} subFunc={subFunc} " +
+                                 $"payload={BitConverter.ToString(frame, 0, Math.Min(frame.Length, 20))}...");
+
+        await _dev.WriteAsync(frame);
+    }
+
+    /// <summary>
+    /// Read a single CPL response frame with timeout.
+    /// Returns null on timeout or disconnect.
+    /// </summary>
+    public CenturionResponse? ReadResponse(int timeoutMs = 2000)
+    {
+        byte[] buffer = new byte[FRAME_SIZE];
+        int bytesRead = _dev.Read(buffer, FRAME_SIZE, timeoutMs);
+
+        if (bytesRead <= 0)
+            return null;
+
+        LogRx(buffer, bytesRead);
+        return ParseFrame(buffer, bytesRead);
+    }
+
+    /// <summary>
+    /// Read a bridge response: discard the immediate ACK, then read the async MessageEvent
+    /// and unwrap the bridge envelope to return the sub-device payload.
+    /// </summary>
+    public CenturionResponse? ReadBridgeResponse(byte bridgeIdx, int timeoutMs = 3000)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            int remainingMs = Math.Max(50, (int)(deadline - DateTimeOffset.UtcNow).TotalMilliseconds);
+            var response = ReadResponse(remainingMs);
+
+            if (response == null)
+                return null;
+
+            var r = response.Value;
+
+            // Skip ACK frames (func=0x01 sendMessage ACK, swid matches ours)
+            if (r.FeatIdx == bridgeIdx && r.FuncId == 0x01 && r.SwId == SWID)
+            {
+                DiagnosticLogger.Verbose("[Centurion] Bridge ACK received, waiting for MessageEvent...");
+                continue;
+            }
+
+            // MessageEvent: bridge feature, func=0x01, swid=0x00 (async event)
+            // Or func=0x00 with swid=0x00 for some firmware versions
+            if (r.FeatIdx == bridgeIdx && r.SwId == 0x00 && r.Params.Length >= 5)
+            {
+                return UnwrapBridgePayload(r.Params);
+            }
+
+            // Not a bridge response - could be unsolicited event, skip
+            DiagnosticLogger.Verbose($"[Centurion] Skipping non-bridge frame: feat=0x{r.FeatIdx:X2} func={r.FuncId} swid={r.SwId}");
+        }
+
+        DiagnosticLogger.LogWarning("[Centurion] Bridge response timeout");
+        return null;
+    }
+
+    /// <summary>
+    /// Continuously read frames, invoking the callback for each one.
+    /// Runs until cancellation or disconnect.
+    /// </summary>
+    public void ReadLoop(Action<CenturionResponse> onFrame, CancellationToken ct)
+    {
+        byte[] buffer = new byte[FRAME_SIZE];
+
+        while (!ct.IsCancellationRequested)
+        {
+            int bytesRead = _dev.Read(buffer, FRAME_SIZE, 500);
+
+            if (bytesRead < 0)
+            {
+                DiagnosticLogger.Log("[Centurion] Device disconnected (read loop)");
+                break;
+            }
+
+            if (bytesRead > 0)
+            {
+                LogRx(buffer, bytesRead);
+                var parsed = ParseFrame(buffer, bytesRead);
+                if (parsed != null)
+                    onFrame(parsed.Value);
+            }
+        }
+    }
+
+    public void Close()
+    {
+        HidClose(_dev);
+    }
+
+    public void Dispose()
+    {
+        Close();
+        GC.SuppressFinalize(this);
+    }
+
+    // ---- Private helpers ----
+
+    private byte[] BuildFrame(byte featIdx, byte func, byte[] parameters)
+    {
+        byte[] frame = new byte[FRAME_SIZE];
+        frame[0] = _reportId;
+        frame[1] = (byte)(3 + parameters.Length); // cpl_length = flags + featIdx + func|swid + params
+        frame[2] = FLAGS_SINGLE;
+        frame[3] = featIdx;
+        frame[4] = (byte)((func << 4) | SWID);
+        Array.Copy(parameters, 0, frame, 5, parameters.Length);
+        return frame;
+    }
+
+    private static CenturionResponse? ParseFrame(byte[] buffer, int bytesRead)
+    {
+        // Minimum valid frame: reportId + cplLen + flags + featIdx + func|swid = 5 bytes
+        if (bytesRead < 5)
+            return null;
+
+        byte cplLen = buffer[1];
+        byte featIdx = buffer[3];
+        byte funcSwid = buffer[4];
+        byte funcId = (byte)((funcSwid >> 4) & 0x0F);
+        byte swId = (byte)(funcSwid & 0x0F);
+
+        // Params start at byte 5, length is cplLen - 3 (flags + featIdx + func|swid)
+        int paramLen = Math.Max(0, cplLen - 3);
+        int available = Math.Max(0, bytesRead - 5);
+        paramLen = Math.Min(paramLen, available);
+
+        byte[] parameters = new byte[paramLen];
+        if (paramLen > 0)
+            Array.Copy(buffer, 5, parameters, 0, paramLen);
+
+        return new CenturionResponse(featIdx, funcId, swId, parameters);
+    }
+
+    private static CenturionResponse? UnwrapBridgePayload(byte[] bridgeParams)
+    {
+        // Bridge payload: [devId<<4|lenHi] [lenLo] [sub_flags] [sub_featIdx] [sub_func|swid] [params...]
+        if (bridgeParams.Length < 5)
+            return null;
+
+        int subMsgLen = ((bridgeParams[0] & 0x0F) << 8) | bridgeParams[1];
+        if (bridgeParams.Length < 2 + subMsgLen || subMsgLen < 3)
+            return null;
+
+        byte subFeatIdx = bridgeParams[3];
+        byte subFuncSwid = bridgeParams[4];
+        byte subFuncId = (byte)((subFuncSwid >> 4) & 0x0F);
+        byte subSwId = (byte)(subFuncSwid & 0x0F);
+
+        int subParamLen = subMsgLen - 3;
+        byte[] subParams = new byte[subParamLen];
+        if (subParamLen > 0)
+            Array.Copy(bridgeParams, 5, subParams, 0, Math.Min(subParamLen, bridgeParams.Length - 5));
+
+        return new CenturionResponse(subFeatIdx, subFuncId, subSwId, subParams);
+    }
+
+    private static void LogTx(string mode, byte featIdx, byte func, byte[] parameters)
+    {
+        DiagnosticLogger.Verbose($"[Centurion] TX {mode}: feat=0x{featIdx:X2} func={func} " +
+                                 $"params={BitConverter.ToString(parameters)}");
+    }
+
+    private static void LogRx(byte[] buffer, int bytesRead)
+    {
+        DiagnosticLogger.Verbose($"[Centurion] RX ({bytesRead} bytes): {BitConverter.ToString(buffer, 0, bytesRead)}");
+    }
+}

--- a/LGSTrayHID/HidApi/HidDeviceInfoHelpers.cs
+++ b/LGSTrayHID/HidApi/HidDeviceInfoHelpers.cs
@@ -7,7 +7,8 @@ public enum HidppMessageType : short
     NONE = 0,
     SHORT,
     LONG,
-    VERY_LONG
+    VERY_LONG,
+    PROBE  // Non-FF00 vendor page with usage 0x0001 — Centurion headset candidate
 }
 
 internal static class HidDeviceInfoHelpers
@@ -24,7 +25,8 @@ internal static class HidDeviceInfoHelpers
     {
         unsafe
         {
-            if ((deviceInfo.UsagePage & 0xFF00) == 0xFF00)
+            // Standard HID++ usage page (FF00 only — not FF13, FFA0, etc.)
+            if (deviceInfo.UsagePage == 0xFF00)
             {
                 return deviceInfo.Usage switch
                 {
@@ -33,10 +35,14 @@ internal static class HidDeviceInfoHelpers
                     _ => HidppMessageType.NONE,
                 };
             }
-            else
+
+            // Other vendor-specific pages with usage 0x0001 — Centurion headset interfaces
+            if ((deviceInfo.UsagePage & 0xFF00) == 0xFF00 && deviceInfo.Usage == 0x0001)
             {
-                return HidppMessageType.NONE;
+                return HidppMessageType.PROBE;
             }
+
+            return HidppMessageType.NONE;
         }
     }
 

--- a/LGSTrayHID/HidppManagerContext.cs
+++ b/LGSTrayHID/HidppManagerContext.cs
@@ -1,4 +1,5 @@
-﻿using LGSTrayHID.HidApi;
+﻿using LGSTrayHID.Centurion;
+using LGSTrayHID.HidApi;
 using LGSTrayPrimitives;
 using LGSTrayPrimitives.MessageStructs;
 using System.Collections.Concurrent;
@@ -81,6 +82,16 @@ public sealed class HidppManagerContext
             case HidppMessageType.VERY_LONG:
                 DiagnosticLogger.Log($"Skipping device with unsupported message type: {messageType}");
                 return 0;
+
+            case HidppMessageType.PROBE:
+            {
+                string probePath = deviceInfo.GetPath();
+                DiagnosticLogger.Log($"[Centurion] Detected Centurion interface 0x{deviceInfo.UsagePage:X4}: {probePath}");
+                HidDevicePtr probeDev = HidOpenPath(ref deviceInfo);
+                var centurion = new CenturionDevice(probeDev, deviceInfo.UsagePage);
+                _ = Task.Run(() => centurion.InitAsync());
+                return 0;
+            }
         }
 
         string devPath = deviceInfo.GetPath();


### PR DESCRIPTION
   ## Summary

   - Adds Centurion CPL protocol transport layer for headsets (G522, PRO X 2, etc.) that use non-standard HID interfaces (usage
   page 0xFFA0+)
   - Supports both **dongle mode** (wireless via CentPPBridge) and **direct USB** (wired) connections
   - Detects Centurion interfaces via `HidppMessageType.PROBE` for non-FF00 vendor pages with usage 0x0001
   - Reports battery percentage and charging status to the tray via existing `BatteryUpdatePublisher` / `SignalDeviceEvent`
   infrastructure

   ## Changes

   - **New:** `LGSTrayHID/Centurion/CenturionTransport.cs` — Low-level 64-byte CPL frame I/O, bridge envelope wrapping/unwrapping
   - **New:** `LGSTrayHID/Centurion/CenturionDevice.cs` — Feature discovery (CenturionRoot → CentPPBridge/BatterySOC), battery
   polling + event handling, device name retrieval
   - **Modified:** `HidDeviceInfoHelpers.cs` — Added `PROBE` message type; narrowed HID++ detection to exact `UsagePage ==
   0xFF00`
   - **Modified:** `HidppManagerContext.cs` — Routes `PROBE` devices to `CenturionDevice` instead of being ignored

   ## Scope

   Battery monitoring only. No audio features (EQ, sidetone, mic), RGB/lighting, or profile management. Replaces the
   diagnostic-only `HidppBlindProber` from the `dev/g522` branch with a functional implementation.

   ## Test plan

   - [ ] Wireless headset via dongle: plug dongle → feature discovery finds CentPPBridge → sub-device BatterySOC → battery
   appears in tray
   - [ ] Wired headset via USB: plug headset → feature discovery finds BatterySOC directly → battery appears in tray
   - [ ] Disconnect/reconnect: headset power off → tray updates; power on → battery reappears
   - [ ] Verify `[Centurion]` diagnostic log messages with `--log --verbose`
   - [ ] Existing HID++ devices (mice, keyboards) unaffected