### PR TITLE
fix: 0x50 variant TX frames missing device address byte

### DIFF
--- a/LGSTrayHID/Centurion/CenturionDevice.cs
+++ b/LGSTrayHID/Centurion/CenturionDevice.cs
@@ -170,7 +170,12 @@ public class CenturionDevice : IDisposable
     /// Completes device registration for dongle mode once the headset is reachable.
     /// Safe to call repeatedly — no-ops immediately if already registered (_pendingInit == false).
     /// </summary>
-    public async Task CompleteInitAsync()
+    /// <param name="headsetOnlineConfirmed">
+    /// When true, skip getConnectionInfo — caller already knows the headset is online
+    /// (e.g. from a ConnectionStateChanged event). Avoids a redundant query that may
+    /// time out during the dongle's own post-wakeup enumeration.
+    /// </param>
+    public async Task CompleteInitAsync(bool headsetOnlineConfirmed = false)
     {
         if (!_pendingInit) return;
 
@@ -182,20 +187,31 @@ public class CenturionDevice : IDisposable
         {
             if (!_pendingInit) return; // Double-check after winning the race
 
-            // Step 1: Contact headset via CentPPBridge.getConnectionInfo (func 0).
-            // This is a direct query to the dongle, not a bridge-wrapped request.
-            var connResp = await _parentChannel.SendAsync(_bridgeIdx, 0x00, []);
-            if (connResp == null)
+            bool headsetReachable = headsetOnlineConfirmed;
+
+            if (!headsetReachable)
             {
-                DiagnosticLogger.LogWarning($"{Tag} CompleteInit: getConnectionInfo timed out — headset likely asleep");
+                // Step 1: Contact headset via CentPPBridge.getConnectionInfo (func 0).
+                // This is a direct query to the dongle, not a bridge-wrapped request.
+                var connResp = await _parentChannel.SendAsync(_bridgeIdx, 0x00, []);
+                if (connResp == null)
+                {
+                    DiagnosticLogger.LogWarning($"{Tag} CompleteInit: getConnectionInfo timed out — headset likely asleep");
+                }
+                else
+                {
+                    DiagnosticLogger.Verbose($"{Tag} CompleteInit getConnectionInfo params: {BitConverter.ToString(connResp.Value.Params)}");
+                    if (connResp.Value.HeadsetOffline)
+                        DiagnosticLogger.Log($"{Tag} CompleteInit: headset offline (HeadsetOffline=true), will retry on connect event");
+                    else
+                        headsetReachable = true;
+                }
             }
-            else
+
+            if (headsetReachable)
             {
-                DiagnosticLogger.Verbose($"{Tag} CompleteInit getConnectionInfo params: {BitConverter.ToString(connResp.Value.Params)}");
-            }
-            if (connResp != null && !connResp.Value.HeadsetOffline)
-            {
-                DiagnosticLogger.Log($"{Tag} Headset connected via bridge");
+                DiagnosticLogger.Log($"{Tag} Headset connected via bridge" +
+                    (headsetOnlineConfirmed ? " (confirmed by event)" : ""));
 
                 // Step 2: Discover sub-device features via bridge
                 byte socIdx    = await QueryFeatureIndex(_subChannel, FEAT_BATTERY_SOC);
@@ -220,10 +236,6 @@ public class CenturionDevice : IDisposable
                 {
                     DiagnosticLogger.LogWarning($"{Tag} CompleteInit: BatterySOC feature not found via bridge — cannot monitor battery");
                 }
-            }
-            else if (connResp != null)
-            {
-                DiagnosticLogger.Log($"{Tag} CompleteInit: headset offline (HeadsetOffline=true), will retry on connect event");
             }
         }
         finally
@@ -314,7 +326,7 @@ public class CenturionDevice : IDisposable
                 try
                 {
                     await Task.Delay(HEADSET_ONLINE_DELAY_MS, _cts.Token);
-                    await CompleteInitAsync();
+                    await CompleteInitAsync(headsetOnlineConfirmed: true);
                 }
                 catch (OperationCanceledException) { }
             });
@@ -347,7 +359,7 @@ public class CenturionDevice : IDisposable
                 try
                 {
                     await Task.Delay(HEADSET_ONLINE_DELAY_MS, _cts.Token); // Wait for RF stability
-                    if (_pendingInit) await CompleteInitAsync();
+                    if (_pendingInit) await CompleteInitAsync(headsetOnlineConfirmed: true);
                     else await UpdateBattery(forceUpdate: true);
                 }
                 catch (OperationCanceledException) { } // Prevent access to disposed objects when shutting down

--- a/LGSTrayHID/Centurion/Transport/CenturionTransport.cs
+++ b/LGSTrayHID/Centurion/Transport/CenturionTransport.cs
@@ -187,21 +187,16 @@ public class CenturionTransport : IDisposable
     // ---- Internal static overloads (testable without a HID device) ----
 
     /// <summary>
-    /// Build a 64-byte CPL request frame. TX layout is always Layout_0x51 (no device
-    /// address) for both variants — the 0x23 source-address byte only appears in RX.
+    /// Build a 64-byte CPL request frame.
+    /// For Layout_0x50: includes device address (0x23) at [1], matching the RX format.
+    /// For Layout_0x51: symmetric (no device address).
     /// </summary>
     internal static byte[] BuildFrame(FrameLayout layout, byte reportId, byte featIdx, byte func, byte[] parameters)
     {
-        // CPL TX frame (64 bytes, zero-padded):
-        //   [0]              reportId
-        //   [CplLenOffset]   3 + params.Length  (counts flags + featIdx + func|swid + params)
-        //   [FlagsOffset]    0x00
-        //   [FeatIdxOffset]  featIdx
-        //   [FuncSwidOffset] func<<4 | SWID
-        //   [ParamsOffset..] params[0..n]
-        //   [rest]           0x00 padding
         byte[] frame = new byte[FrameLayout.FRAME_SIZE];
         frame[0] = reportId;
+        if (layout.DeviceAddress.HasValue)
+            frame[1] = layout.DeviceAddress.Value;
         frame[layout.CplLenOffset]   = (byte)(3 + parameters.Length);
         frame[layout.FlagsOffset]    = FLAGS_SINGLE;
         frame[layout.FeatIdxOffset]  = featIdx;

--- a/LGSTrayHID/Centurion/Transport/CenturionTransportShort.cs
+++ b/LGSTrayHID/Centurion/Transport/CenturionTransportShort.cs
@@ -4,11 +4,11 @@ namespace LGSTrayHID.Centurion.Transport;
 
 /// <summary>
 /// 0x50 (G522, Centurion SHORT) transport variant.
-/// RX frames have an extra device-address byte at [1]; TX is still symmetric.
+/// Both TX and RX frames include a device address byte (0x23) at position [1].
 /// </summary>
 public sealed class CenturionTransportShort(HidDevicePtr dev)
     : CenturionTransport(dev, reportId: 0x50)
 {
+    protected override FrameLayout TxLayout => FrameLayout.Layout_0x50;
     protected override FrameLayout RxLayout => FrameLayout.Layout_0x50;
-    // TxLayout intentionally NOT overridden — TX is symmetric for 0x50
 }

--- a/LGSTrayHID/Centurion/Transport/FrameLayout.cs
+++ b/LGSTrayHID/Centurion/Transport/FrameLayout.cs
@@ -8,15 +8,16 @@ namespace LGSTrayHID.Centurion.Transport;
 // 0x50 (G522, Centurion SHORT) — device address 0x23 inserted at [1] in every RX frame:
 //   [0] reportId  [1] 0x23(devAddr)  [2] cplLen  [3] flags  [4] featIdx  [5] func|swid  [6+] params
 //
-// TX frames are always symmetric (no device address) regardless of report ID.
+// 0x50 TX frames also require the 0x23 device address at [1], matching RX format.
 public readonly record struct FrameLayout(
     int CplLenOffset,   // byte index of payloadLen
     int FlagsOffset,    // byte index of flags
     int FeatIdxOffset,  // byte index of feature index
     int FuncSwidOffset, // byte index of func<<4|swid
-    int ParamsOffset)   // byte index of first param byte
+    int ParamsOffset,   // byte index of first param byte
+    byte? DeviceAddress = null) // device address byte inserted at [1] for 0x50 variant
 {
     public static FrameLayout Layout_0x51 => new(CplLenOffset: 1, FlagsOffset: 2, FeatIdxOffset: 3, FuncSwidOffset: 4, ParamsOffset: 5);
-    public static FrameLayout Layout_0x50 => new(CplLenOffset: 2, FlagsOffset: 3, FeatIdxOffset: 4, FuncSwidOffset: 5, ParamsOffset: 6);
+    public static FrameLayout Layout_0x50 => new(CplLenOffset: 2, FlagsOffset: 3, FeatIdxOffset: 4, FuncSwidOffset: 5, ParamsOffset: 6, DeviceAddress: 0x23);
     public const int FRAME_SIZE = 64;
 }


### PR DESCRIPTION
Summary

  The 0x50 Centurion transport variant (G522 dongle, PID 0x0B18) requires a 0x23 device address byte at position
  [1] in TX frames — the same format as its RX frames. Without this byte, the dongle silently drops all requests,
  causing every ROOT query, getConnectionInfo call, and bridge request to time out after 2000ms.

  Root Cause

  The original implementation assumed TX frames were symmetric (no device address) across all Centurion variants.
  This is true for the 0x51 variant (PRO X 2), but not for 0x50. The evidence:

  - Every RX frame from 0x50 devices has 0x23 at byte[1]
  - Without it in TX, no request ever gets a response — only unsolicited events (ConnectionStateChanged, firmware
  enumeration traffic with SwId=0x0F) are ever received
  - With the fix, TX frames match the device's expected format and queries should get responses

  Diagnosed from the 4_min_wireless_diagnostic.log and 1_min_wired_diagnostic.log — both showed identical symptoms
  across PID 0x0B18 (dongle) and PID 0x0B19 (wired).

  Changes

  - FrameLayout.cs: Added nullable DeviceAddress field. Layout_0x50 sets it to 0x23; Layout_0x51 leaves it null (no
   behavioral change for 0x51 devices).
  - CenturionTransport.cs: BuildFrame writes the device address at frame[1] when the layout specifies one.
  - CenturionTransportShort.cs: Override TxLayout => Layout_0x50 (previously only overrode RxLayout).
  - CenturionDevice.cs: CompleteInitAsync now accepts a headsetOnlineConfirmed flag. When triggered by a
  ConnectionStateChanged event (which already proves the headset is online), it skips the redundant
  getConnectionInfo query and proceeds directly to sub-device feature discovery. This avoids a timeout during the
  dongle's own post-wakeup enumeration window.

  Testing needed

  - Wireless via dongle: ROOT queries should now get responses, bridge discovery + BatterySOC should succeed
  - Wired via USB: ROOT queries should respond, direct BatterySOC discovery should work
  - Headset asleep at startup: deferred mode should still work — event-driven bridge discovery triggers
  CompleteInitAsync with the skip-getConnectionInfo path
  - Existing 0x51 devices (PRO X 2): no behavioral change (Layout_0x51 has DeviceAddress = null)
  - Verbose logs should show TX frames with 0x23 at byte[1] for 0x50 variant
