### PR TITLE
Here's another PR covering what I saw in the G522 logs from the user.

### DIFF
--- a/LGSTrayHID.Tests/FrameParsingTests_0x50.cs
+++ b/LGSTrayHID.Tests/FrameParsingTests_0x50.cs
@@ -6,7 +6,7 @@ namespace LGSTrayHID.Tests;
 public class FrameParsingTests_0x50
 {
     private static CenturionResponse? Parse(string hexDash) =>
-        CenturionTransport.ParseFrame(FrameLayout.Layout_0x50, LogFrame.Parse(hexDash), 64);
+        CenturionTransport.ParseFrame(FrameLayout.Layout_0x50_RxOnly, LogFrame.Parse(hexDash), 64);
 
     [Fact]
     public void GetFeatureResponse()
@@ -59,7 +59,7 @@ public class FrameParsingTests_0x50
     [Fact]
     public void TooShort_ReturnsNull()
     {
-        var result = CenturionTransport.ParseFrame(FrameLayout.Layout_0x50, LogFrame.Parse("50-23"), 2);
+        var result = CenturionTransport.ParseFrame(FrameLayout.Layout_0x50_RxOnly, LogFrame.Parse("50-23"), 2);
         Assert.Null(result);
     }
 
@@ -67,7 +67,7 @@ public class FrameParsingTests_0x50
     public void BufferNotReachingFuncSwidOffset_ReturnsNull()
     {
         // FuncSwidOffset=5; bytesRead=5 is not > 5
-        var result = CenturionTransport.ParseFrame(FrameLayout.Layout_0x50, LogFrame.Parse("50-23-06-00-00"), 5);
+        var result = CenturionTransport.ParseFrame(FrameLayout.Layout_0x50_RxOnly, LogFrame.Parse("50-23-06-00-00"), 5);
         Assert.Null(result);
     }
 }

--- a/LGSTrayHID/Centurion/CenturionDevice.cs
+++ b/LGSTrayHID/Centurion/CenturionDevice.cs
@@ -42,7 +42,7 @@ public class CenturionDevice : IDisposable
 
     // Device state
     private const byte _subDeviceId = 0x00;   // Solaar's comment: device_id=0 for the headset
-    private string _deviceName = "Centurion Headset";
+    private string _deviceName;
     private string _identifier = string.Empty;
     private string? _serialNumber;
     private string? _modelId;
@@ -76,10 +76,11 @@ public class CenturionDevice : IDisposable
     private const int HEADSET_ONLINE_DELAY_MS = 1000;    // time to wait for RF link to stabilise after wakeup
     private const int PENDING_INIT_POLL_INTERVAL_S = 15;
 
-    public CenturionDevice(HidDevicePtr dev, ushort usagePage)
+    public CenturionDevice(HidDevicePtr dev, ushort usagePage, string? productName = null)
     {
         _transport = CenturionTransportFactory.Create(dev);
         _usagePage = usagePage;
+        _deviceName = productName ?? "Centurion Headset";
     }
 
     public async Task InitAsync()

--- a/LGSTrayHID/Centurion/CenturionDevice.cs
+++ b/LGSTrayHID/Centurion/CenturionDevice.cs
@@ -289,6 +289,18 @@ public class CenturionDevice : IDisposable
 
                 if (frame.SwId == 0x00)
                 {
+                    // Centurion error response: feat=0xFF, swid=0, params=[original_swid, error_code].
+                    // The device sends this when a feature doesn't exist on the parent.
+                    // Fail the pending request immediately instead of letting it timeout.
+                    if (frame.FeatIdx == 0xFF && frame.Params.Length >= 1 && frame.Params[0] == CenturionTransport.SWID)
+                    {
+                        DiagnosticLogger.Verbose($"{Tag} Dispatcher: error response (feat=0xFF) — feature not found");
+                        bool handled = _subChannel.TryCompleteError(frame);
+                        if (!handled && !ReferenceEquals(_subChannel, _parentChannel))
+                            _parentChannel.TryCompleteError(frame);
+                        continue;
+                    }
+
                     var toForward = _subChannel.RouteEvent(frame);
                     if (toForward != null)
                         await HandleAsyncEvent(toForward.Value);

--- a/LGSTrayHID/Centurion/CenturionTransportFactory.cs
+++ b/LGSTrayHID/Centurion/CenturionTransportFactory.cs
@@ -22,9 +22,14 @@ public static class CenturionTransportFactory
         else
             DiagnosticLogger.LogWarning("[Centurion] Unknown report ID — passive sniff mode (RX logging only)");
 
+        if (reportId == 0x50)
+        {
+            byte deviceAddr = ProbeDeviceAddress(dev, reportId.Value);
+            return new CenturionTransportShort(dev, deviceAddr);
+        }
+
         return reportId switch
         {
-            0x50 => new CenturionTransportShort(dev),
             0x51 => new CenturionTransportLong(dev),
             null => new CenturionTransportPassive(dev),
             _    => new CenturionTransportLong(dev, reportId.Value) // unknown variant, try base layout
@@ -42,5 +47,30 @@ public static class CenturionTransportFactory
                 return reportId;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Probe the device address for 0x50-variant devices by reading the first RX frame.
+    /// The address is always at byte[1] of every frame the device sends.
+    /// Falls back to 0x23 (G522 default) if no frame arrives within the timeout.
+    /// </summary>
+    private static byte ProbeDeviceAddress(HidDevicePtr dev, byte reportId)
+    {
+        const byte FALLBACK_ADDR = 0x23;
+
+        // The DetectReportId write (all-zeros with valid report ID) may have triggered
+        // a response or error frame. Try reading it. Also catches any pending unsolicited frame.
+        byte[] buffer = new byte[FrameLayout.FRAME_SIZE];
+        int bytesRead = dev.Read(buffer, FrameLayout.FRAME_SIZE, 500);
+
+        if (bytesRead >= 2 && buffer[0] == reportId)
+        {
+            byte addr = buffer[1];
+            DiagnosticLogger.Log($"[Centurion] Probed device address: 0x{addr:X2}");
+            return addr;
+        }
+
+        DiagnosticLogger.LogWarning($"[Centurion] Could not probe device address, using fallback 0x{FALLBACK_ADDR:X2}");
+        return FALLBACK_ADDR;
     }
 }

--- a/LGSTrayHID/Centurion/Channel/CenturionChannel.cs
+++ b/LGSTrayHID/Centurion/Channel/CenturionChannel.cs
@@ -100,6 +100,20 @@ public abstract class CenturionChannel : IDisposable
     }
 
     /// <summary>
+    /// Called by the dispatcher for error frames (feat=0xFF, swid=0).
+    /// Cancels the pending request so SendCoreAsync returns null immediately.
+    /// Returns false if no pending request exists (allows dispatcher to try another channel).
+    /// </summary>
+    public bool TryCompleteError(CenturionResponse frame)
+    {
+        var pending = Interlocked.Exchange(ref _pendingRequest, null);
+        if (pending == null)
+            return false;
+        pending.Tcs.TrySetCanceled();
+        return true;
+    }
+
+    /// <summary>
     /// Atomically exchange out _pendingRequest and complete it if it matches the frame.
     /// Returns false if there was no pending request (allows caller to try another channel).
     /// </summary>

--- a/LGSTrayHID/Centurion/Transport/CenturionTransport.cs
+++ b/LGSTrayHID/Centurion/Transport/CenturionTransport.cs
@@ -188,7 +188,7 @@ public class CenturionTransport : IDisposable
 
     /// <summary>
     /// Build a 64-byte CPL request frame.
-    /// For Layout_0x50: includes device address (0x23) at [1], matching the RX format.
+    /// For Layout_0x50: includes probed device address at [1], matching the RX format.
     /// For Layout_0x51: symmetric (no device address).
     /// </summary>
     internal static byte[] BuildFrame(FrameLayout layout, byte reportId, byte featIdx, byte func, byte[] parameters)

--- a/LGSTrayHID/Centurion/Transport/CenturionTransportShort.cs
+++ b/LGSTrayHID/Centurion/Transport/CenturionTransportShort.cs
@@ -4,11 +4,19 @@ namespace LGSTrayHID.Centurion.Transport;
 
 /// <summary>
 /// 0x50 (G522, Centurion SHORT) transport variant.
-/// Both TX and RX frames include a device address byte (0x23) at position [1].
+/// Both TX and RX frames include a device address byte at position [1].
+/// The address is probed from the device's first RX frame during factory creation.
 /// </summary>
-public sealed class CenturionTransportShort(HidDevicePtr dev)
-    : CenturionTransport(dev, reportId: 0x50)
+public sealed class CenturionTransportShort : CenturionTransport
 {
-    protected override FrameLayout TxLayout => FrameLayout.Layout_0x50;
-    protected override FrameLayout RxLayout => FrameLayout.Layout_0x50;
+    private readonly FrameLayout _layout;
+
+    public CenturionTransportShort(HidDevicePtr dev, byte deviceAddress)
+        : base(dev, reportId: 0x50)
+    {
+        _layout = FrameLayout.Layout_0x50(deviceAddress);
+    }
+
+    protected override FrameLayout TxLayout => _layout;
+    protected override FrameLayout RxLayout => _layout;
 }

--- a/LGSTrayHID/Centurion/Transport/FrameLayout.cs
+++ b/LGSTrayHID/Centurion/Transport/FrameLayout.cs
@@ -8,7 +8,8 @@ namespace LGSTrayHID.Centurion.Transport;
 // 0x50 (G522, Centurion SHORT) — device address 0x23 inserted at [1] in every RX frame:
 //   [0] reportId  [1] 0x23(devAddr)  [2] cplLen  [3] flags  [4] featIdx  [5] func|swid  [6+] params
 //
-// 0x50 TX frames also require the 0x23 device address at [1], matching RX format.
+// 0x50 TX frames also require the device address at [1], matching RX format.
+// The address (e.g. 0x23 on G522) is device-specific and probed at startup.
 public readonly record struct FrameLayout(
     int CplLenOffset,   // byte index of payloadLen
     int FlagsOffset,    // byte index of flags
@@ -18,6 +19,20 @@ public readonly record struct FrameLayout(
     byte? DeviceAddress = null) // device address byte inserted at [1] for 0x50 variant
 {
     public static FrameLayout Layout_0x51 => new(CplLenOffset: 1, FlagsOffset: 2, FeatIdxOffset: 3, FuncSwidOffset: 4, ParamsOffset: 5);
-    public static FrameLayout Layout_0x50 => new(CplLenOffset: 2, FlagsOffset: 3, FeatIdxOffset: 4, FuncSwidOffset: 5, ParamsOffset: 6, DeviceAddress: 0x23);
+
+    /// <summary>
+    /// Create a 0x50-variant layout with the given device address at byte[1].
+    /// The address is probed from the first RX frame during transport creation.
+    /// </summary>
+    public static FrameLayout Layout_0x50(byte deviceAddress) =>
+        new(CplLenOffset: 2, FlagsOffset: 3, FeatIdxOffset: 4, FuncSwidOffset: 5, ParamsOffset: 6, DeviceAddress: deviceAddress);
+
+    /// <summary>
+    /// Offset constants for 0x50 RX parsing (before device address is known).
+    /// Same field positions as Layout_0x50 but without a DeviceAddress for TX.
+    /// </summary>
+    public static FrameLayout Layout_0x50_RxOnly =>
+        new(CplLenOffset: 2, FlagsOffset: 3, FeatIdxOffset: 4, FuncSwidOffset: 5, ParamsOffset: 6);
+
     public const int FRAME_SIZE = 64;
 }

--- a/LGSTrayHID/HidApi/HidDeviceInfoHelpers.cs
+++ b/LGSTrayHID/HidApi/HidDeviceInfoHelpers.cs
@@ -21,6 +21,15 @@ internal static class HidDeviceInfoHelpers
         }
     }
 
+    internal static string? GetProductString(this HidDeviceInfo deviceInfo)
+    {
+        unsafe
+        {
+            if (deviceInfo.ProductString == null) return null;
+            return Marshal.PtrToStringUni((nint)deviceInfo.ProductString);
+        }
+    }
+
     internal static HidppMessageType GetHidppMessageType(this HidDeviceInfo deviceInfo)
     {
         unsafe

--- a/LGSTrayHID/HidppManagerContext.cs
+++ b/LGSTrayHID/HidppManagerContext.cs
@@ -94,7 +94,8 @@ public sealed class HidppManagerContext
                     DiagnosticLogger.LogError($"[Centurion] Failed to open HID device: {probePath}");
                     return 0;
                 }
-                var centurion = new CenturionDevice(probeDev, deviceInfo.UsagePage);
+                string? productName = deviceInfo.GetProductString();
+                var centurion = new CenturionDevice(probeDev, deviceInfo.UsagePage, productName);
                 _centurionMap[probePath] = centurion;
                 _ = Task.Run(() => centurion.InitAsync());
                 return 0;


### PR DESCRIPTION
Three fixes on top of feat/centurion-headset-battery (commit 3605579), based on analysis of the diagnostic logs from the G522 user.

1. Detect Centurion error responses (feat=0xFF) immediately

When the parent device doesn't have a feature (e.g. BatterySOC 0x0104, DeviceName 0x0101 — both sub-device-only), it responds with an error frame:

  feat=0xFF, func=0, swid=0, params=[original_swid, error_code]

Previously the dispatcher routed these to HandleAsyncEvent (because swid=0), which ignored them. The pending request then waited the full 2s timeout. With two missing parent features that's ~4s of unnecessary delay during wireless init.

Now the dispatcher detects feat=0xFF with params[0] == SWID as an error response and cancels the pending request immediately. QueryFeatureIndex gets its null back in milliseconds instead of seconds.

  This also helps wired mode — the wired headset (PID 0x0B19) returns feat=0xFF for the CentPPBridge query since it has no bridge. With instant error detection, the code correctly falls through to direct BatterySOC discovery without waiting for the timeout.

 2. Probe 0x50 device address instead of hardcoding 0x23

The device address byte at position [1] in 0x50-variant frames was hardcoded to 0x23. This is correct for the G522 dongle but other devices using report ID 0x50 might use a different address.

Now CenturionTransportFactory reads the first RX frame after report ID detection and extracts byte[1] as the device address. Falls back to 0x23 if no frame arrives within 500ms.

  - FrameLayout.Layout_0x50 is now a method: Layout_0x50(byte deviceAddress)
  - FrameLayout.Layout_0x50_RxOnly added for parsing contexts (tests) where the TX address isn't needed
  - CenturionTransportShort takes the probed address in its constructor

3. Use USB ProductString as default device name

Devices that lack the DeviceName feature (0x0101), like the G522, were showing "Centurion Headset" in the tray. Now the USB descriptor ProductString is read from HidDeviceInfo at detection time and passed as the default name. The Centurion DeviceName feature still overrides it when available (e.g. PRO X 2 has it at sub-device index 2).

Precedence: DeviceName feature (0x0101) > USB ProductString > "Centurion Headset" fallback

Notes for future work

Usage page 0xFF43: The protocol docs indicate wired USB audio devices may use usage page 0xFF43 with Centurion framing (vs 0xFFA0 for wireless dongles). The current detection only matches 0xFFA0. This could be added when a device using 0xFF43 is available for testing — it would just be another condition in GetHidppMessageType.

DeviceInfo func 1 (getFirmwareVersion): The protocol docs show this returns a firmwareName string (bytes 5+). Currently only func 0 (hardware info) and func 2 (serial) are queried. The firmware name might provide useful model identification for devices where neither DeviceName nor ProductString give a good name.

