### PR TITLE
refr: FrameLayout cleanup and passive transport guard

### DIFF
--- a/LGSTrayHID.Tests/FrameParsingTests_0x50.cs
+++ b/LGSTrayHID.Tests/FrameParsingTests_0x50.cs
@@ -6,7 +6,7 @@ namespace LGSTrayHID.Tests;
 public class FrameParsingTests_0x50
 {
     private static CenturionResponse? Parse(string hexDash) =>
-        CenturionTransport.ParseFrame(FrameLayout.Layout_0x50_RxOnly, LogFrame.Parse(hexDash), 64);
+        CenturionTransport.ParseFrame(FrameLayout.Layout_0x50, LogFrame.Parse(hexDash), 64);
 
     [Fact]
     public void GetFeatureResponse()
@@ -59,7 +59,7 @@ public class FrameParsingTests_0x50
     [Fact]
     public void TooShort_ReturnsNull()
     {
-        var result = CenturionTransport.ParseFrame(FrameLayout.Layout_0x50_RxOnly, LogFrame.Parse("50-23"), 2);
+        var result = CenturionTransport.ParseFrame(FrameLayout.Layout_0x50, LogFrame.Parse("50-23"), 2);
         Assert.Null(result);
     }
 
@@ -67,7 +67,7 @@ public class FrameParsingTests_0x50
     public void BufferNotReachingFuncSwidOffset_ReturnsNull()
     {
         // FuncSwidOffset=5; bytesRead=5 is not > 5
-        var result = CenturionTransport.ParseFrame(FrameLayout.Layout_0x50_RxOnly, LogFrame.Parse("50-23-06-00-00"), 5);
+        var result = CenturionTransport.ParseFrame(FrameLayout.Layout_0x50, LogFrame.Parse("50-23-06-00-00"), 5);
         Assert.Null(result);
     }
 }

--- a/LGSTrayHID/Centurion/CenturionTransportFactory.cs
+++ b/LGSTrayHID/Centurion/CenturionTransportFactory.cs
@@ -1,6 +1,7 @@
 using LGSTrayHID.Centurion.Transport;
 using LGSTrayHID.HidApi;
 using LGSTrayPrimitives;
+using System.Diagnostics;
 using static LGSTrayHID.HidApi.HidApi;
 
 namespace LGSTrayHID.Centurion;
@@ -11,32 +12,28 @@ namespace LGSTrayHID.Centurion;
 /// </summary>
 public static class CenturionTransportFactory
 {
-    // Candidate report IDs tried in order    
+    // Candidate report IDs tried in order
     private static readonly byte[] ReportIdCandidates = [0x51, 0x50];
 
     public static CenturionTransport Create(HidDevicePtr dev)
     {
-        byte? reportId = DetectReportId(dev);
+        byte? reportId = ProbeReportId(dev);
         if (reportId.HasValue)
             DiagnosticLogger.Log($"[Centurion] Detected variant: report ID 0x{reportId:X2}");
         else
             DiagnosticLogger.LogWarning("[Centurion] Unknown report ID — passive sniff mode (RX logging only)");
 
-        if (reportId == 0x50)
-        {
-            byte deviceAddr = ProbeDeviceAddress(dev, reportId.Value);
-            return new CenturionTransportShort(dev, deviceAddr);
-        }
-
         return reportId switch
         {
+            0x50 => new CenturionTransportShort(dev, ProbeDeviceAddress(dev, reportId.Value)),
             0x51 => new CenturionTransportLong(dev),
             null => new CenturionTransportPassive(dev),
-            _    => new CenturionTransportLong(dev, reportId.Value) // unknown variant, try base layout
+            // All defined candidates must be assigned to transports
+            _ => throw new UnreachableException($"ProbeReportId returned 0x{reportId:X2}: defined transport not assigned")
         };
     }
 
-    private static byte? DetectReportId(HidDevicePtr dev)
+    private static byte? ProbeReportId(HidDevicePtr dev)
     {
         byte[] probe = new byte[FrameLayout.FRAME_SIZE];
         foreach (byte reportId in ReportIdCandidates)

--- a/LGSTrayHID/Centurion/CenturionTransportFactory.cs
+++ b/LGSTrayHID/Centurion/CenturionTransportFactory.cs
@@ -55,7 +55,7 @@ public static class CenturionTransportFactory
     {
         const byte FALLBACK_ADDR = 0x23;
 
-        // The DetectReportId write (all-zeros with valid report ID) may have triggered
+        // The ProbeReportId write (all-zeros with valid report ID) may have triggered
         // a response or error frame. Try reading it. Also catches any pending unsolicited frame.
         byte[] buffer = new byte[FrameLayout.FRAME_SIZE];
         int bytesRead = dev.Read(buffer, FrameLayout.FRAME_SIZE, 500);

--- a/LGSTrayHID/Centurion/Transport/CenturionTransport.cs
+++ b/LGSTrayHID/Centurion/Transport/CenturionTransport.cs
@@ -176,7 +176,7 @@ public class CenturionTransport : IDisposable
 
     // ---- Private helpers ----
 
-    private byte[] BuildFrame(byte featIdx, byte func, byte[] parameters)
+    protected virtual byte[] BuildFrame(byte featIdx, byte func, byte[] parameters)
     {
         if (IsPassive)
             throw new InvalidOperationException("Cannot send: transport is in passive sniff mode");
@@ -187,16 +187,13 @@ public class CenturionTransport : IDisposable
     // ---- Internal static overloads (testable without a HID device) ----
 
     /// <summary>
-    /// Build a 64-byte CPL request frame.
-    /// For Layout_0x50: includes probed device address at [1], matching the RX format.
-    /// For Layout_0x51: symmetric (no device address).
+    /// Build a 64-byte CPL request frame using the given layout offsets.
+    /// Device-address injection (0x50 variant) is handled by CenturionTransportShort.
     /// </summary>
     internal static byte[] BuildFrame(FrameLayout layout, byte reportId, byte featIdx, byte func, byte[] parameters)
     {
         byte[] frame = new byte[FrameLayout.FRAME_SIZE];
         frame[0] = reportId;
-        if (layout.DeviceAddress.HasValue)
-            frame[1] = layout.DeviceAddress.Value;
         frame[layout.CplLenOffset]   = (byte)(3 + parameters.Length);
         frame[layout.FlagsOffset]    = FLAGS_SINGLE;
         frame[layout.FeatIdxOffset]  = featIdx;

--- a/LGSTrayHID/Centurion/Transport/CenturionTransport.cs
+++ b/LGSTrayHID/Centurion/Transport/CenturionTransport.cs
@@ -40,6 +40,7 @@ public class CenturionTransport : IDisposable
     /// </summary>
     public virtual async Task SendDirectRequest(byte featIdx, byte func, byte[] parameters)
     {
+        if (IsPassive) { DiagnosticLogger.LogWarning("[Centurion] Cannot send direct request: passive transport"); return; }
         byte[] frame = BuildFrame(featIdx, func, parameters);
         LogTx("Direct", featIdx, func, parameters);
         await _dev.WriteAsync(frame);
@@ -55,6 +56,7 @@ public class CenturionTransport : IDisposable
     /// </summary>
     public virtual async Task SendBridgeRequest(byte bridgeIdx, byte devId, byte subFeatIdx, byte subFunc, byte[] subParams)
     {
+        if (IsPassive) { DiagnosticLogger.LogWarning("[Centurion] Cannot send bridge request: passive transport"); return; }
         // Sub-device message: [sub_cpl=0x00] [sub_feat_idx] [sub_func|swid] [params...]
         int subMsgLen = 3 + subParams.Length;
 
@@ -177,11 +179,7 @@ public class CenturionTransport : IDisposable
     // ---- Private helpers ----
 
     protected virtual byte[] BuildFrame(byte featIdx, byte func, byte[] parameters)
-    {
-        if (IsPassive)
-            throw new InvalidOperationException("Cannot send: transport is in passive sniff mode");
-        return BuildFrame(TxLayout, ReportId, featIdx, func, parameters);
-    }
+        => BuildFrame(TxLayout, ReportId, featIdx, func, parameters);
     //private CenturionResponse? ParseFrame(byte[] buffer, int bytesRead) => ParseFrame(RxLayout, buffer, bytesRead);
 
     // ---- Internal static overloads (testable without a HID device) ----

--- a/LGSTrayHID/Centurion/Transport/CenturionTransportShort.cs
+++ b/LGSTrayHID/Centurion/Transport/CenturionTransportShort.cs
@@ -22,7 +22,7 @@ public sealed class CenturionTransportShort : CenturionTransport
 
     protected override byte[] BuildFrame(byte featIdx, byte func, byte[] parameters)
     {
-        byte[] frame = base.BuildFrame(featIdx, func, parameters);
+        byte[] frame = CenturionTransport.BuildFrame(TxLayout, ReportId, featIdx, func, parameters);
         frame[1] = _deviceAddress;
         return frame;
     }

--- a/LGSTrayHID/Centurion/Transport/CenturionTransportShort.cs
+++ b/LGSTrayHID/Centurion/Transport/CenturionTransportShort.cs
@@ -9,14 +9,21 @@ namespace LGSTrayHID.Centurion.Transport;
 /// </summary>
 public sealed class CenturionTransportShort : CenturionTransport
 {
-    private readonly FrameLayout _layout;
+    private readonly byte _deviceAddress;
 
     public CenturionTransportShort(HidDevicePtr dev, byte deviceAddress)
         : base(dev, reportId: 0x50)
     {
-        _layout = FrameLayout.Layout_0x50(deviceAddress);
+        _deviceAddress = deviceAddress;
     }
 
-    protected override FrameLayout TxLayout => _layout;
-    protected override FrameLayout RxLayout => _layout;
+    protected override FrameLayout TxLayout => FrameLayout.Layout_0x50;
+    protected override FrameLayout RxLayout => FrameLayout.Layout_0x50;
+
+    protected override byte[] BuildFrame(byte featIdx, byte func, byte[] parameters)
+    {
+        byte[] frame = base.BuildFrame(featIdx, func, parameters);
+        frame[1] = _deviceAddress;
+        return frame;
+    }
 }

--- a/LGSTrayHID/Centurion/Transport/FrameLayout.cs
+++ b/LGSTrayHID/Centurion/Transport/FrameLayout.cs
@@ -5,34 +5,19 @@ namespace LGSTrayHID.Centurion.Transport;
 // 0x51 (PRO X 2, Centurion LONG) — symmetric, no device address:
 //   [0] reportId  [1] cplLen  [2] flags  [3] featIdx  [4] func|swid  [5+] params
 //
-// 0x50 (G522, Centurion SHORT) — device address 0x23 inserted at [1] in every RX frame:
-//   [0] reportId  [1] 0x23(devAddr)  [2] cplLen  [3] flags  [4] featIdx  [5] func|swid  [6+] params
+// 0x50 (G522, Centurion SHORT) — device address inserted at [1] in every frame:
+//   [0] reportId  [1] devAddr  [2] cplLen  [3] flags  [4] featIdx  [5] func|swid  [6+] params
 //
-// 0x50 TX frames also require the device address at [1], matching RX format.
-// The address (e.g. 0x23 on G522) is device-specific and probed at startup.
+// The device address is a protocol detail of CenturionTransportShort; it is not part of the layout.
 public readonly record struct FrameLayout(
     int CplLenOffset,   // byte index of payloadLen
     int FlagsOffset,    // byte index of flags
     int FeatIdxOffset,  // byte index of feature index
     int FuncSwidOffset, // byte index of func<<4|swid
-    int ParamsOffset,   // byte index of first param byte
-    byte? DeviceAddress = null) // device address byte inserted at [1] for 0x50 variant
+    int ParamsOffset)   // byte index of first param byte
 {
     public static FrameLayout Layout_0x51 => new(CplLenOffset: 1, FlagsOffset: 2, FeatIdxOffset: 3, FuncSwidOffset: 4, ParamsOffset: 5);
-
-    /// <summary>
-    /// Create a 0x50-variant layout with the given device address at byte[1].
-    /// The address is probed from the first RX frame during transport creation.
-    /// </summary>
-    public static FrameLayout Layout_0x50(byte deviceAddress) =>
-        new(CplLenOffset: 2, FlagsOffset: 3, FeatIdxOffset: 4, FuncSwidOffset: 5, ParamsOffset: 6, DeviceAddress: deviceAddress);
-
-    /// <summary>
-    /// Offset constants for 0x50 RX parsing (before device address is known).
-    /// Same field positions as Layout_0x50 but without a DeviceAddress for TX.
-    /// </summary>
-    public static FrameLayout Layout_0x50_RxOnly =>
-        new(CplLenOffset: 2, FlagsOffset: 3, FeatIdxOffset: 4, FuncSwidOffset: 5, ParamsOffset: 6);
+    public static FrameLayout Layout_0x50 => new(CplLenOffset: 2, FlagsOffset: 3, FeatIdxOffset: 4, FuncSwidOffset: 5, ParamsOffset: 6);
 
     public const int FRAME_SIZE = 64;
 }


### PR DESCRIPTION
- Remove DeviceAddress from FrameLayout; collapse Layout_0x50(byte) and Layout_0x50_RxOnly into a single Layout_0x50
- Move device address ownership into CenturionTransportShort; override BuildFrame to inject it at frame[1]
- Document the _ switch arm as unreachable given the current candidate list
- SendDirectRequest / SendBridgeRequest — guard passive mode with a log + early return instead of throwing
